### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -86,7 +86,7 @@ Every time you manually add photos to disk you must scan by visiting /photos/sca
 == Version history
 
 1.2.3
-- Rails 1.2.3
+- Rails 3.2
 
 1.2.2
 - Rails 3.1


### PR DESCRIPTION
just fixing a small mistake at the version history.
at version 1.2.3 Balder supports Rails 3.2
