### PR TITLE
upgrade to rails 3.2.18 for security and adding required gem scrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 
 gem 'rails', '~> 3.2'
 
+gem 'scrypt'
 gem 'authlogic'
 gem 'omniauth'
 gem 'omniauth-facebook'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,10 @@ GEM
     excon (0.33.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.3)
+    ffi-compiler (0.1.3)
+      ffi (>= 1.0.0)
+      rake
     fog (1.22.0)
       fog-brightbox
       fog-core (~> 1.21, >= 1.21.1)
@@ -137,6 +141,9 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     request_store (1.0.5)
+    scrypt (1.2.1)
+      ffi-compiler (>= 0.0.2)
+      rake
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -172,5 +179,6 @@ DEPENDENCIES
   pg
   rails (~> 3.2)
   rails_12factor
+  scrypt
   sqlite3-ruby
   unicorn


### PR DESCRIPTION
I got this error running balder 

`LoadError (cannot load such file -- scrypt)`

so, adding this gem ...

and upgrading rails to latest
